### PR TITLE
Add Module as Service Provider

### DIFF
--- a/imageroot/actions/create-module/90service_provider
+++ b/imageroot/actions/create-module/90service_provider
@@ -2,7 +2,7 @@
 
 #
 # Copyright (C) 2023 Nethesis S.r.l.
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 '''

--- a/imageroot/actions/create-module/90service_provider
+++ b/imageroot/actions/create-module/90service_provider
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+'''
+Expose metrics.
+'''
+
+import os
+
+import agent
+
+# expose service provider
+with agent.redis_connect() as ro_redis_client:
+    host = ro_redis_client.hget(f'node/{os.environ["NODE_ID"]}/vpn', 'ip_address')
+    with agent.redis_connect(privileged=True) as redis_client:
+        module_id = os.environ["MODULE_ID"]
+        redis_client.hset(f'module/{module_id}/srv/http/prometheus-metrics', 'host', host)
+        redis_client.hset(f'module/{module_id}/srv/http/prometheus-metrics',
+                          'path', os.environ["NODE_EXPORTER_PATH"])
+        redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')

--- a/imageroot/actions/create-module/90service_provider
+++ b/imageroot/actions/create-module/90service_provider
@@ -10,15 +10,24 @@ Expose metrics.
 '''
 
 import os
+import json
 
 import agent
 
 # expose service provider
-with agent.redis_connect() as ro_redis_client:
-    host = ro_redis_client.hget(f'node/{os.environ["NODE_ID"]}/vpn', 'ip_address')
-    with agent.redis_connect(privileged=True) as redis_client:
-        module_id = os.environ["MODULE_ID"]
-        redis_client.hset(f'module/{module_id}/srv/http/prometheus-metrics', 'host', host)
-        redis_client.hset(f'module/{module_id}/srv/http/prometheus-metrics',
-                          'path', os.environ["NODE_EXPORTER_PATH"])
-        redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')
+ro_redis_client = agent.redis_connect(use_replica=True)
+host = ro_redis_client.hget(f'node/{os.environ["NODE_ID"]}/vpn', 'ip_address')
+
+redis_client = agent.redis_connect(privileged=True)
+module_id = os.environ["MODULE_ID"]
+
+data = {
+    "hosts": [
+        host
+    ],
+    "labels": {
+        "__metrics_path__": os.environ["NODE_EXPORTER_PATH"]
+    }
+}
+redis_client.hset(f'module/{module_id}/srv/http/prometheus-metrics', 'config', json.dumps(data))
+redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')

--- a/imageroot/actions/destroy-module/20service_provider
+++ b/imageroot/actions/destroy-module/20service_provider
@@ -2,7 +2,7 @@
 
 #
 # Copyright (C) 2023 Nethesis S.r.l.
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 '''

--- a/imageroot/actions/destroy-module/20service_provider
+++ b/imageroot/actions/destroy-module/20service_provider
@@ -14,7 +14,7 @@ import os
 import agent
 
 # remove configuration
-with agent.redis_connect(privileged=True) as redis_client:
-    module_id = os.environ["MODULE_ID"]
-    redis_client.delete(f'module/{module_id}/srv/http/prometheus-metrics')
-    redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')
+redis_client =  agent.redis_connect(privileged=True)
+module_id = os.environ["MODULE_ID"]
+redis_client.delete(f'module/{module_id}/srv/http/prometheus-metrics')
+redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')

--- a/imageroot/actions/destroy-module/20service_provider
+++ b/imageroot/actions/destroy-module/20service_provider
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+'''
+Remove exposed metrics.
+'''
+
+import os
+
+import agent
+
+# remove configuration
+with agent.redis_connect(privileged=True) as redis_client:
+    module_id = os.environ["MODULE_ID"]
+    redis_client.delete(f'module/{module_id}/srv/http/prometheus-metrics')
+    redis_client.publish(f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')


### PR DESCRIPTION
Allow node_exporter to be discovered by prometheus using `prometheus-metrics` as name for Service Provider.
Requires/depends on: NethServer/ns8-prometheus#4